### PR TITLE
[Item] imageOrder 필드

### DIFF
--- a/src/main/java/com/swyp/artego/domain/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/swyp/artego/domain/item/dto/request/ItemCreateRequest.java
@@ -44,7 +44,7 @@ public class ItemCreateRequest {
 
     private StatusType statusType;
 
-    // TODO: imageOrder 필드 추가, 관련 로직 추가
+    private List<String> imageOrder;
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/swyp/artego/domain/item/dto/request/ItemUpdateRequest.java
+++ b/src/main/java/com/swyp/artego/domain/item/dto/request/ItemUpdateRequest.java
@@ -40,7 +40,7 @@ public class ItemUpdateRequest {
 
     private StatusType statusType;
 
-    private List<String> orderedImageList; // TODO: imageOrder로 이름 변경
+    private List<String> imageOrder;
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/swyp/artego/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/item/service/ItemServiceImpl.java
@@ -87,7 +87,7 @@ public class ItemServiceImpl implements ItemService {
         }
 
         // 이미지 요소 검증 및 imgUrls 반환, 사용하지 않는 사진은 삭제
-        List<String> orderedList = request.getOrderedImageList();
+        List<String> orderedList = request.getImageOrder();
         validateFileSizeAndNameMatch(multipartFiles, orderedList);
 
         List<String> updatedImageUrls = uploadNewImagesInOrderWithRollback(multipartFiles, orderedList);

--- a/src/test/java/com/swyp/artego/global/file/service/FileServiceTest.java
+++ b/src/test/java/com/swyp/artego/global/file/service/FileServiceTest.java
@@ -186,6 +186,29 @@ class FileServiceTest {
         assertEquals(ErrorCode.IO_ERROR, exception.getErrorCode());
     }
 
+    /**
+     * [테스트] uploadNewFilesInOrder 메서드 - 파일 업로드 도중 IOException 발생 시 롤백 및 예외 처리 검증
+     * <p>
+     * 파일 업로드 과정에서 IOException이 발생하는 경우,
+     * 업로드된 파일들을 롤백(delete)한 후 BusinessExceptionHandler(IO_ERROR)를 발생시켜야 한다.
+     */
+    @Test
+    void uploadNewFilesInOrder_shouldRollbackAndThrowIOException_whenFileUploadFails() {
+        // given
+        mockMultipartFiles.add(new IOExceptionMultipartFile(
+                "files", "test-IOFail-image.jpg", "image/jpeg", "Fail Content".getBytes()));
+
+        List<String> imageOrder = List.of("test-image1.jpg", "test-image2.png", "test-IOFail-image.jpg");
+
+        // when + then
+        BusinessExceptionHandler exception = assertThrows(
+                BusinessExceptionHandler.class,
+                () -> fileService.uploadNewFilesInOrder(mockMultipartFiles, imageOrder, folderName)
+        );
+
+        assertEquals(ErrorCode.IO_ERROR, exception.getErrorCode());
+    }
+
     static class IOExceptionMultipartFile extends MockMultipartFile {
 
         public IOExceptionMultipartFile(String name, String originalFilename, String contentType, byte[] content) {


### PR DESCRIPTION
사용자가 요청한 사진 순서를 파악하기 위한 imageOrder 필드

- 수정 API의 기존 OrderedImageList 필드를 ImageOrder로 수정
- 등록 API에 ImageOrder 필드 추가 및 관련 로직 추가
- validateFileSizeAndNameMatch()는 Set으로 비교
- uploadNewFilesInOrder는 FileService로 분리
- uploadNewFilesInOrder 단위 테스트