### PR TITLE
[Comment] 게시글 별 조회 API 응답 필드 수정

### DIFF
--- a/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
@@ -66,7 +66,6 @@ public class CommentController {
 
     /**
      * 댓글/대댓글 수정 API
-     * TODO: 기획- 답글이 달린 경우, 수정 불가능하게?
      */
     @PatchMapping("/{commentId}")
     @Operation(summary = "댓글/대댓글 수정")

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -1,6 +1,5 @@
 package com.swyp.artego.domain.comment.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.swyp.artego.domain.comment.entity.Comment;
 import lombok.AllArgsConstructor;
@@ -46,7 +45,7 @@ public class CommentFindByItemIdResponse {
 
     /**
      * flat 구조의 댓글 목록을 depth 1의 계층형 댓글 응답 구조로 변환한다.
-     *
+     * <p>
      * parent가 null인 댓글을 루트 댓글로 간주하고,
      * 해당 댓글을 기준으로 직접적인 자식(대댓글)들을 묶어 replies 필드에 포함한다.
      * 대댓글은 루트 댓글 하나에만 속하며, 추가 중첩은 지원하지 않는다.
@@ -88,7 +87,7 @@ public class CommentFindByItemIdResponse {
                     .user(UserInfo.builder()
                             .id(parent.getUser().getId())
                             .name(parent.getUser().getName())
-                            .imgUrl("user's imgUrl") // TODO: 프로필 사진 연동하기
+                            .imgUrl(parent.getUser().getImgUrl())
                             .build())
                     .comment(CommentInfo.builder()
                             .id(parent.getId())

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
@@ -10,12 +10,13 @@ import java.util.List;
 @Getter
 @Builder
 public class CommentFindByItemIdWrapperResponse {
-    // TODO: 댓글 총 개수 필드 추가
+    private int totalCount;
     private CommentFindByItemIdResponse.UserInfo creator;
     private List<CommentFindByItemIdResponse> comments;
 
     public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> flatList) {
         return CommentFindByItemIdWrapperResponse.builder()
+                .totalCount(flatList.size())
                 .creator(CommentFindByItemIdResponse.UserInfo.builder()
                         .id(creator.getId())
                         .name(creator.getName())

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
@@ -19,7 +19,7 @@ public class CommentFindByItemIdWrapperResponse {
                 .creator(CommentFindByItemIdResponse.UserInfo.builder()
                         .id(creator.getId())
                         .name(creator.getName())
-                        .imgUrl("creator's imgUrl") // TODO: 프로필 사진 연동하기
+                        .imgUrl(creator.getImgUrl())
                         .build())
                 .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(flatList))
                 .build();


### PR DESCRIPTION
- 실제 프로필 imgUrl 전송하도록 연동(기존엔 하드코딩)
- 게시글 별 조회API 응답에 총 댓글 수를 의미하는 totalCount 필드 추가