### PR TITLE
[Comment] 등록/삭제/조회 API 로직 및 dto 수정

### DIFF
--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -38,7 +38,7 @@ public class CommentFindByItemIdResponse {
         private Long writerId;
         private String comment;
         private boolean secret;
-
+        private boolean deleted;
 
         private LocalDateTime createdAt;
     }
@@ -81,6 +81,7 @@ public class CommentFindByItemIdResponse {
                             .writerId(reply.getUser().getId())
                             .comment(reply.getComment())
                             .secret(reply.isSecret())
+                            .deleted(reply.isDeleted())
                             .createdAt(reply.getCreatedAt())
                             .build())
                     .toList();
@@ -96,6 +97,7 @@ public class CommentFindByItemIdResponse {
                             .writerId(parent.getUser().getId())
                             .comment(parent.getComment())
                             .secret(parent.isSecret())
+                            .deleted(parent.isDeleted())
                             .createdAt(parent.getCreatedAt())
                             .build())
                     .replies(replyResponses.isEmpty() ? null : replyResponses)

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -47,17 +47,18 @@ public class CommentFindByItemIdResponse {
      * flat 구조의 댓글 목록을 depth 1의 계층형 댓글 응답 구조로 변환한다.
      * <p>
      * parent가 null인 댓글을 루트 댓글로 간주하고,
-     * 해당 댓글을 기준으로 직접적인 자식(대댓글)들을 묶어 replies 필드에 포함한다.
+     * 해당 댓글을 기준으로 재귀적인 자식(대댓글)들을 묶어 replies 필드에 포함한다.
+     * replies는 createdAt 오래된 순으로 정렬한다.
      * 대댓글은 루트 댓글 하나에만 속하며, 추가 중첩은 지원하지 않는다.
      *
-     * @param flatList 계층 구조 없이 정렬된 Comment 엔티티 리스트
+     * @param comments 계층 구조 없는 Comment 엔티티 리스트
      * @return List<CommentFindByItemIdResponse> 루트 댓글과 그에 속한 대댓글을 포함하는 응답 DTO 리스트
      */
-    public static List<CommentFindByItemIdResponse> convertFlatToDepth1Tree(List<Comment> flatList) {
+    public static List<CommentFindByItemIdResponse> convertFlatToDepth1Tree(List<Comment> comments) {
         Map<Long, List<Comment>> repliesGroupedByParentId = new HashMap<>();
         List<Comment> parents = new ArrayList<>();
 
-        for (Comment comment : flatList) {
+        for (Comment comment : comments) {
             if (comment.getParent() == null) {
                 parents.add(comment);
             } else {
@@ -71,9 +72,10 @@ public class CommentFindByItemIdResponse {
         List<CommentFindByItemIdResponse> responseList = new ArrayList<>();
 
         for (Comment parent : parents) {
-            List<Comment> replies = repliesGroupedByParentId.getOrDefault(parent.getId(), Collections.emptyList());
+            List<Comment> flatReplies = getAllRecursiveReplies(parent.getId(), repliesGroupedByParentId);
+            flatReplies.sort(Comparator.comparing(Comment::getCreatedAt));
 
-            List<CommentInfo> replyResponses = replies.stream()
+            List<CommentInfo> replyResponses = flatReplies.stream()
                     .map(reply -> CommentInfo.builder()
                             .id(reply.getId())
                             .writerId(reply.getUser().getId())
@@ -101,7 +103,27 @@ public class CommentFindByItemIdResponse {
 
             responseList.add(response);
         }
-
         return responseList;
+    }
+
+    /**
+     * 지정된 댓글 ID를 부모로 갖는 모든 하위 댓글을 재귀적으로 수집하여 평탄한 리스트로 반환합니다.
+     *
+     * <p>댓글 간 계층 구조를 유지하지 않고, 시간 순 정렬을 위해 하나의 flat 리스트로 구성됩니다.
+     *
+     * @param parentId   현재 댓글의 ID (루트 또는 상위 댓글 ID)
+     * @param repliesMap 부모 댓글 ID를 키로, 그에 속한 자식 댓글 리스트를 값으로 갖는 맵
+     * @return 주어진 부모 댓글에 속한 모든 하위 댓글 리스트 (depth 제한 없음, 순서 보장 안 됨)
+     */
+    private static List<Comment> getAllRecursiveReplies(Long parentId, Map<Long, List<Comment>> repliesMap) {
+        List<Comment> result = new ArrayList<>();
+        List<Comment> children = repliesMap.getOrDefault(parentId, Collections.emptyList());
+
+        for (Comment child : children) {
+            result.add(child);
+            result.addAll(getAllRecursiveReplies(child.getId(), repliesMap));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
@@ -14,15 +14,15 @@ public class CommentFindByItemIdWrapperResponse {
     private CommentFindByItemIdResponse.UserInfo creator;
     private List<CommentFindByItemIdResponse> comments;
 
-    public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> flatList) {
+    public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> comments) {
         return CommentFindByItemIdWrapperResponse.builder()
-                .totalCount(flatList.size())
+                .totalCount(comments.size())
                 .creator(CommentFindByItemIdResponse.UserInfo.builder()
                         .id(creator.getId())
                         .name(creator.getName())
                         .imgUrl(creator.getImgUrl())
                         .build())
-                .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(flatList))
+                .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(comments))
                 .build();
     }
 }

--- a/src/main/java/com/swyp/artego/domain/comment/entity/Comment.java
+++ b/src/main/java/com/swyp/artego/domain/comment/entity/Comment.java
@@ -22,11 +22,11 @@ public class Comment extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="item_id")
+    @JoinColumn(name = "item_id")
     private Item item;
 
     @Setter
@@ -37,6 +37,11 @@ public class Comment extends BaseTimeEntity {
     @Convert(converter = BooleanToYNConverter.class)
     @Column(name = "secret", length = 1, nullable = false)
     private boolean secret;
+
+    @Setter
+    @Convert(converter = BooleanToYNConverter.class)
+    @Column(name = "deleted", length = 1, nullable = false)
+    private boolean deleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
@@ -10,5 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByItemIdOrderByCreatedAtDesc(@Param("itemId") Long itemId);
 
+    Comment findByParentId(@Param("parentId") Long parentId);
+
     List<Comment> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
@@ -2,25 +2,12 @@ package com.swyp.artego.domain.comment.repository;
 
 import com.swyp.artego.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("""
-    SELECT c
-    FROM Comment c
-    WHERE c.item.id = :itemId
-    ORDER BY
-        COALESCE(c.parent.id, c.id) DESC,
-        CASE
-            WHEN c.parent IS NULL THEN 0
-            ELSE 1
-        END,
-        c.createdAt ASC
-    """)
     List<Comment> findByItemIdOrderByCreatedAtDesc(@Param("itemId") Long itemId);
 
     List<Comment> findAllByOrderByCreatedAtDesc();

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
@@ -28,15 +28,6 @@ public interface CommentService {
     CommentFindByItemIdWrapperResponse getCommentsByItemId(Long itemId);
 
     /**
-     * 댓글/대댓글 삭제
-     *
-     * @param user      댓글 삭제를 시도하는 유저
-     * @param commentId 삭제하려는 댓글의 id
-     * @return CommentDeleteResponse
-     */
-    CommentDeleteResponse deleteComment(AuthUser user, Long commentId);
-
-    /**
      * 댓글/대댓글 수정
      *
      * @param user      댓글 수정을 시도하는 유저
@@ -44,4 +35,13 @@ public interface CommentService {
      * @return CommentUpdateResponse
      */
     CommentUpdateResponse updateComment(AuthUser user, Long commentId, CommentUpdateRequest request);
+
+    /**
+     * 댓글/대댓글 삭제
+     *
+     * @param user      댓글 삭제를 시도하는 유저
+     * @param commentId 삭제하려는 댓글의 id
+     * @return CommentDeleteResponse
+     */
+    CommentDeleteResponse deleteComment(AuthUser user, Long commentId);
 }

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
@@ -39,11 +39,13 @@ public class CommentServiceImpl implements CommentService {
         Item item = itemRepository.findById(request.getItemId())
                 .orElseThrow(() -> new BusinessExceptionHandler("작품이 존재하지 않습니다.", ErrorCode.NOT_FOUND_ERROR));
 
-        // parentComment 가 존재하면 대댓글 작성 요청임
-        // TODO: 존재하지 않는 ParentID 면 예외 발생. 현재는 null로 저장됨.
-        Comment parentComment = commentRepository.findById(request.getParentCommentId()).orElse(null);
-        if (parentComment != null) {
-            validateReplyCommentPermission(user, parentComment, item);
+        Comment parentComment = null;
+        if (request.getParentCommentId() != null) {
+            parentComment = commentRepository.findById(request.getParentCommentId())
+                    .orElseThrow(() -> new BusinessExceptionHandler("존재하지 않는 parentId 입니다.", ErrorCode.NOT_FOUND_ERROR));
+            if (parentComment != null) {
+                validateReplyCommentPermission(user, parentComment, item);
+            }
         }
 
         return CommentCreateResponse.fromEntity(

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
@@ -56,9 +56,9 @@ public class CommentServiceImpl implements CommentService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessExceptionHandler("존재하지 않는 작품입니다.", ErrorCode.NOT_FOUND_ERROR));
 
-        List<Comment> flatList = commentRepository.findByItemIdOrderByCreatedAtDesc(itemId);
+        List<Comment> comments = commentRepository.findByItemIdOrderByCreatedAtDesc(itemId);
 
-        return CommentFindByItemIdWrapperResponse.from(item.getUser(), flatList);
+        return CommentFindByItemIdWrapperResponse.from(item.getUser(), comments);
     }
 
     @Override


### PR DESCRIPTION
### 등록
- 존재하지 않는 parentId 요청 시 예외 발생
- parentId = null 요청 시 루트 댓글로 저장

### 삭제
- 아무 댓글도 commentId를 parentId로 갖지 않아야 실제 삭제 가능.
- commentId를 parentId로 갖는 댓글의 경우 "삭제된 댓글입니다." 라고 표시함.

### 조회
- 기존: 모든 대댓글이 루트 댓글의 parentId만 참조
- 댓글 구조를 실제 트리 형태로 반영하여 재귀적으로 하위 댓글을 수집하도록 수정
- 응답 구조는 동일하지만, 내부 비즈니스 로직에서 재귀 수집 방식으로 변경됨