### PR TITLE
Feat/#93: [댓글] rootComment 정책 변경 및 비밀 댓글 정책 적용 

### DIFF
--- a/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
@@ -44,14 +44,14 @@ public class CommentController {
 
     /**
      * 작품 별 전체 댓글 조회 API
-     * TODO: 프런트 연동 이후 @AuthenticationPrincipal AuthUser user 를 추가, 볼 수 있는/없는 댓글을 응답에 적용한다.
      */
     @GetMapping("/item/{itemId}")
     @Operation(summary = "작품 별 댓글/대댓글 전체 조회")
     public ResponseEntity<ApiResponse<CommentFindByItemIdWrapperResponse>> getCommentsByItemId(
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long itemId) {
 
-        CommentFindByItemIdWrapperResponse res = commentService.getCommentsByItemId(itemId);
+        CommentFindByItemIdWrapperResponse res = commentService.getCommentsByItemId(authUser, itemId);
 
         return ResponseEntity.status(SuccessCode.SELECT_SUCCESS.getStatus())
                 .body(ApiResponse.<CommentFindByItemIdWrapperResponse>builder()

--- a/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
@@ -29,10 +29,10 @@ public class CommentController {
     @PostMapping("")
     @Operation(summary = "댓글/대댓글 등록")
     public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
-            @AuthenticationPrincipal AuthUser user,
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestBody @Valid CommentCreateRequest request) {
 
-        CommentCreateResponse res = commentService.createComment(user, request);
+        CommentCreateResponse res = commentService.createComment(authUser, request);
 
         return ResponseEntity.status(SuccessCode.INSERT_SUCCESS.getStatus())
                 .body(ApiResponse.<CommentCreateResponse>builder()
@@ -64,11 +64,11 @@ public class CommentController {
     @GetMapping("/my-activities")
     @Operation(summary = "내가 작성한 댓글 기반 활동 목록 조회 (작품별 최신 댓글 + 작가 대댓글 포함)")
     public ResponseEntity<ApiResponse<MyCommentActivityResultResponse>> getMyCommentActivities(
-            @AuthenticationPrincipal AuthUser user,
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int limit) {
 
-        MyCommentActivityResultResponse result = commentService.getMyCommentActivities(user, page, limit);
+        MyCommentActivityResultResponse result = commentService.getMyCommentActivities(authUser, page, limit);
 
         return ResponseEntity.status(SuccessCode.SELECT_SUCCESS.getStatus())
                 .body(ApiResponse.<MyCommentActivityResultResponse>builder()

--- a/src/main/java/com/swyp/artego/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/request/CommentCreateRequest.java
@@ -24,15 +24,15 @@ public class CommentCreateRequest {
     @Schema(example = "false", nullable = true)
     private Boolean secret;
 
-    private Long parentCommentId;
+    private Long rootCommentId;
 
-    public Comment toEntity(User user, Item item, Comment parentComment){
+    public Comment toEntity(User user, Item item, Comment rootComment) {
         return Comment.builder()
                 .user(user)
                 .item(item)
                 .comment(this.comment)
                 .secret(this.secret != null ? secret : false)
-                .parent(parentComment)
+                .parent(rootComment)
                 .build();
     }
 

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -15,7 +15,6 @@ public class CommentFindByItemIdResponse {
 
     private UserInfo user;
     private CommentInfo comment;
-    // TODO: private boolean canSee;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<CommentInfo> replies;

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -34,12 +34,13 @@ public class CommentFindByItemIdResponse {
     @AllArgsConstructor
     @Builder
     public static class CommentInfo {
+        private Long rootCommentId;
+
         private Long id;
         private Long writerId;
         private String comment;
         private boolean secret;
         private boolean deleted;
-
         private LocalDateTime createdAt;
     }
 
@@ -47,18 +48,18 @@ public class CommentFindByItemIdResponse {
      * flat 구조의 댓글 목록을 depth 1의 계층형 댓글 응답 구조로 변환한다.
      * <p>
      * parent가 null인 댓글을 루트 댓글로 간주하고,
-     * 해당 댓글을 기준으로 재귀적인 자식(대댓글)들을 묶어 replies 필드에 포함한다.
+     * 해당 댓글을 기준으로 직접적인 자식(대댓글)들을 묶어 replies 필드에 포함한다.
      * replies는 createdAt 오래된 순으로 정렬한다.
      * 대댓글은 루트 댓글 하나에만 속하며, 추가 중첩은 지원하지 않는다.
      *
-     * @param comments 계층 구조 없는 Comment 엔티티 리스트
+     * @param flatList 계층 구조 없이 정렬된 Comment 엔티티 리스트
      * @return List<CommentFindByItemIdResponse> 루트 댓글과 그에 속한 대댓글을 포함하는 응답 DTO 리스트
      */
-    public static List<CommentFindByItemIdResponse> convertFlatToDepth1Tree(List<Comment> comments) {
+    public static List<CommentFindByItemIdResponse> convertFlatToDepth1Tree(List<Comment> flatList) {
         Map<Long, List<Comment>> repliesGroupedByParentId = new HashMap<>();
         List<Comment> parents = new ArrayList<>();
 
-        for (Comment comment : comments) {
+        for (Comment comment : flatList) {
             if (comment.getParent() == null) {
                 parents.add(comment);
             } else {
@@ -72,11 +73,11 @@ public class CommentFindByItemIdResponse {
         List<CommentFindByItemIdResponse> responseList = new ArrayList<>();
 
         for (Comment parent : parents) {
-            List<Comment> flatReplies = getAllRecursiveReplies(parent.getId(), repliesGroupedByParentId);
-            flatReplies.sort(Comparator.comparing(Comment::getCreatedAt));
+            List<Comment> replies = repliesGroupedByParentId.getOrDefault(parent.getId(), Collections.emptyList());
 
-            List<CommentInfo> replyResponses = flatReplies.stream()
+            List<CommentInfo> replyResponses = replies.stream()
                     .map(reply -> CommentInfo.builder()
+                            .rootCommentId(reply.getParent().getId())
                             .id(reply.getId())
                             .writerId(reply.getUser().getId())
                             .comment(reply.getComment())
@@ -93,6 +94,7 @@ public class CommentFindByItemIdResponse {
                             .imgUrl(parent.getUser().getImgUrl())
                             .build())
                     .comment(CommentInfo.builder()
+                            .rootCommentId(null)
                             .id(parent.getId())
                             .writerId(parent.getUser().getId())
                             .comment(parent.getComment())
@@ -106,26 +108,5 @@ public class CommentFindByItemIdResponse {
             responseList.add(response);
         }
         return responseList;
-    }
-
-    /**
-     * 지정된 댓글 ID를 부모로 갖는 모든 하위 댓글을 재귀적으로 수집하여 평탄한 리스트로 반환합니다.
-     *
-     * <p>댓글 간 계층 구조를 유지하지 않고, 시간 순 정렬을 위해 하나의 flat 리스트로 구성됩니다.
-     *
-     * @param parentId   현재 댓글의 ID (루트 또는 상위 댓글 ID)
-     * @param repliesMap 부모 댓글 ID를 키로, 그에 속한 자식 댓글 리스트를 값으로 갖는 맵
-     * @return 주어진 부모 댓글에 속한 모든 하위 댓글 리스트 (depth 제한 없음, 순서 보장 안 됨)
-     */
-    private static List<Comment> getAllRecursiveReplies(Long parentId, Map<Long, List<Comment>> repliesMap) {
-        List<Comment> result = new ArrayList<>();
-        List<Comment> children = repliesMap.getOrDefault(parentId, Collections.emptyList());
-
-        for (Comment child : children) {
-            result.add(child);
-            result.addAll(getAllRecursiveReplies(child.getId(), repliesMap));
-        }
-
-        return result;
     }
 }

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
@@ -2,12 +2,25 @@ package com.swyp.artego.domain.comment.repository;
 
 import com.swyp.artego.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> ,CommentQueryRepository{
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
 
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.item.id = :itemId
+            ORDER BY
+                COALESCE(c.parent.id, c.id) DESC,
+                CASE
+                    WHEN c.parent IS NULL THEN 0
+                    ELSE 1
+                END,
+                c.createdAt ASC
+            """)
     List<Comment> findByItemIdOrderByCreatedAtDesc(@Param("itemId") Long itemId);
 
     Comment findByParentId(@Param("parentId") Long parentId);

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
 
+    // TODO: line 22, c.createdAt ASC 를 사용하면 정렬이 제대로 안되는 문제가 있음.
     @Query("""
             SELECT c
             FROM Comment c
@@ -19,7 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
                     WHEN c.parent IS NULL THEN 0
                     ELSE 1
                 END,
-                c.createdAt ASC
+                c.id ASC
             """)
     List<Comment> findByItemIdOrderByCreatedAtDesc(@Param("itemId") Long itemId);
 

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
@@ -10,11 +10,11 @@ public interface CommentService {
     /**
      * 댓글/대댓글 작성
      *
-     * @param user    댓글/대댓글을 작성하는 유저
+     * @param authUser 댓글/대댓글을 작성하는 유저
      * @param request
      * @return CommentCreateResponse
      */
-    CommentCreateResponse createComment(AuthUser user, CommentCreateRequest request);
+    CommentCreateResponse createComment(AuthUser authUser, CommentCreateRequest request);
 
     /**
      * 작품 별 댓글 전체 조회 (최신순)
@@ -28,23 +28,23 @@ public interface CommentService {
     /**
      * 유저 페이지 댓글 목록 (최신순)
      */
-    MyCommentActivityResultResponse getMyCommentActivities(AuthUser user, int page, int limit);
+    MyCommentActivityResultResponse getMyCommentActivities(AuthUser authUser, int page, int limit);
 
     /**
      * 댓글/대댓글 수정
      *
-     * @param user      댓글 수정을 시도하는 유저
+     * @param authUser  댓글 수정을 시도하는 유저
      * @param commentId 수정하려는 댓글의 id
      * @return CommentUpdateResponse
      */
-    CommentUpdateResponse updateComment(AuthUser user, Long commentId, CommentUpdateRequest request);
+    CommentUpdateResponse updateComment(AuthUser authUser, Long commentId, CommentUpdateRequest request);
 
     /**
      * 댓글/대댓글 삭제
      *
-     * @param user      댓글 삭제를 시도하는 유저
+     * @param authUser  댓글 삭제를 시도하는 유저
      * @param commentId 삭제하려는 댓글의 id
      * @return CommentDeleteResponse
      */
-    CommentDeleteResponse deleteComment(AuthUser user, Long commentId);
+    CommentDeleteResponse deleteComment(AuthUser authUser, Long commentId);
 }

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
@@ -22,7 +22,7 @@ public interface CommentService {
      * @param itemId 댓글을 조회할 작품 Id
      * @return CommentFindByItemIdWrapperResponse
      */
-    CommentFindByItemIdWrapperResponse getCommentsByItemId(Long itemId);
+    CommentFindByItemIdWrapperResponse getCommentsByItemId(AuthUser authUser, Long itemId);
 
 
     /**

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
@@ -64,8 +64,8 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional(readOnly = true)
-    public MyCommentActivityResultResponse getMyCommentActivities(AuthUser user, int page, int limit) {
-        return commentRepository.findMyCommentActivity(user, page, limit);
+    public MyCommentActivityResultResponse getMyCommentActivities(AuthUser authUser, int page, int limit) {
+        return commentRepository.findMyCommentActivity(authUser, page, limit);
     }
 
 

--- a/src/test/java/com/swyp/artego/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/swyp/artego/domain/comment/service/CommentServiceImplTest.java
@@ -70,16 +70,16 @@ class CommentServiceImplTest {
     @DisplayName("[대댓글 작성] 성공 - 사용자2 댓글에 대댓을 다는 크리에이터1")
     void createComment_createReply_shouldWorkSuccessfully_whenReplyCreatedByCreator() {
         // given
-        Comment parentComment = new Comment(user2, item1, "", false, null);
-        ReflectionTestUtils.setField(parentComment, "id", 1L);
+        Comment rootComment = new Comment(user2, item1, "", false, null);
+        ReflectionTestUtils.setField(rootComment, "id", 1L);
 
-        Comment replyComment = new Comment(creator1, item1, "대댓글 내용", false, parentComment);
+        Comment replyComment = new Comment(creator1, item1, "대댓글 내용", false, rootComment);
         ReflectionTestUtils.setField(replyComment, "id", 2L);
 
         CommentCreateRequest request = CommentCreateRequest.builder()
                 .itemId(item1.getId())
                 .comment("대댓글 내용")
-                .parentCommentId(parentComment.getId())
+                .rootCommentId(rootComment.getId())
                 .build();
 
         given(userRepository.findByOauthId(authCreator1.getOauthId())
@@ -88,8 +88,8 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findById(parentComment.getId())
-        ).willReturn(Optional.of(parentComment));
+        given(commentRepository.findById(rootComment.getId())
+        ).willReturn(Optional.of(rootComment));
 
         given(commentRepository.save(any(Comment.class)))
                 .willReturn(replyComment);
@@ -110,13 +110,13 @@ class CommentServiceImplTest {
         User anotherUser3 = User.builder().oauthId(anotherAuthUser3.getOauthId()).build();
         ReflectionTestUtils.setField(anotherUser3, "id", 3L);
 
-        Comment parentComment = new Comment(user2, item1, "", false, null);
-        ReflectionTestUtils.setField(parentComment, "id", 1L);
+        Comment rootComment = new Comment(user2, item1, "", false, null);
+        ReflectionTestUtils.setField(rootComment, "id", 1L);
 
         CommentCreateRequest request = CommentCreateRequest.builder()
                 .itemId(item1.getId())
                 .comment("대댓글 내용")
-                .parentCommentId(parentComment.getId())
+                .rootCommentId(rootComment.getId())
                 .build();
 
         given(userRepository.findByOauthId(anotherAuthUser3.getOauthId())
@@ -125,8 +125,8 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findById(parentComment.getId())
-        ).willReturn(Optional.of(parentComment));
+        given(commentRepository.findById(rootComment.getId())
+        ).willReturn(Optional.of(rootComment));
 
         // when + then
         BusinessExceptionHandler exception = assertThrows(
@@ -142,13 +142,13 @@ class CommentServiceImplTest {
     @DisplayName("[대댓글 작성] 예외 발생 - 크리에이터1 댓글에 대댓을 다는 사용자2")
     void createComment_createReply_shouldThrowBusinessException_whenReplyCreatedByNonCreator() {
         // given
-        Comment parentComment = new Comment(creator1, item1, "", false, null);
-        ReflectionTestUtils.setField(parentComment, "id", 1L);
+        Comment rootComment = new Comment(creator1, item1, "", false, null);
+        ReflectionTestUtils.setField(rootComment, "id", 1L);
 
         CommentCreateRequest request = CommentCreateRequest.builder()
                 .itemId(item1.getId())
                 .comment("대댓글 내용")
-                .parentCommentId(parentComment.getId())
+                .rootCommentId(rootComment.getId())
                 .build();
 
         given(userRepository.findByOauthId(authUser2.getOauthId())
@@ -157,8 +157,8 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findById(parentComment.getId())
-        ).willReturn(Optional.of(parentComment));
+        given(commentRepository.findById(rootComment.getId())
+        ).willReturn(Optional.of(rootComment));
 
         // when + then
         BusinessExceptionHandler exception = assertThrows(
@@ -173,8 +173,8 @@ class CommentServiceImplTest {
     @Test
     @DisplayName("[댓글 삭제] 예외 발생 - 다른 사용자가 댓글을 삭제 시도")
     void deleteComment_shouldThrowBusinessException_whenInvalidUserRequest() {
-        Comment parentComment = new Comment(user2, item1, "", false, null);
-        ReflectionTestUtils.setField(parentComment, "id", 1L);
+        Comment rootComment = new Comment(user2, item1, "", false, null);
+        ReflectionTestUtils.setField(rootComment, "id", 1L);
 
         AuthUser anotherAuthUser3 = createAuthUser();
         User anotherUser3 = User.builder().oauthId(anotherAuthUser3.getOauthId()).build();
@@ -183,13 +183,13 @@ class CommentServiceImplTest {
         given(userRepository.findByOauthId(anotherAuthUser3.getOauthId())
         ).willReturn(Optional.of(anotherUser3));
 
-        given(commentRepository.findById(parentComment.getId())
-        ).willReturn(Optional.of(parentComment));
+        given(commentRepository.findById(rootComment.getId())
+        ).willReturn(Optional.of(rootComment));
 
         // when + then
         BusinessExceptionHandler exception = assertThrows(
                 BusinessExceptionHandler.class,
-                () -> commentServiceImpl.deleteComment(anotherAuthUser3, parentComment.getId())
+                () -> commentServiceImpl.deleteComment(anotherAuthUser3, rootComment.getId())
         );
 
         assertEquals(ErrorCode.FORBIDDEN_ERROR, exception.getErrorCode());


### PR DESCRIPTION
- 댓글 구조를 1-depth 기반으로 변경하여 루트 댓글 기준으로 대댓글 저장 (초기 정책으로 돌아감)
- 비밀 댓글 정책 적용
 - 비밀 댓글인 경우 setComment("비밀 댓글입니다.") 로 내용 가림.
 - 루트 댓글의 작성자는 해당 스레드를 모두 열람할 수 있다.
 - 작가는 모든 댓글을 열람할 수 있다.
 - 로그인한 제 3자나 로그인하지 않은 유저는 비밀 댓글을 볼 수 없다.