### PR TITLE
Feat/#93: [댓글] 조회 API 페이지네이션 및 응답 DTO 변경

### DIFF
--- a/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/swyp/artego/domain/comment/controller/CommentController.java
@@ -49,9 +49,11 @@ public class CommentController {
     @Operation(summary = "작품 별 댓글/대댓글 전체 조회")
     public ResponseEntity<ApiResponse<CommentFindByItemIdWrapperResponse>> getCommentsByItemId(
             @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer limit,
             @PathVariable Long itemId) {
 
-        CommentFindByItemIdWrapperResponse res = commentService.getCommentsByItemId(authUser, itemId);
+        CommentFindByItemIdWrapperResponse res = commentService.getCommentsByItemId(authUser, itemId, page, limit);
 
         return ResponseEntity.status(SuccessCode.SELECT_SUCCESS.getStatus())
                 .body(ApiResponse.<CommentFindByItemIdWrapperResponse>builder()

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdResponse.java
@@ -25,7 +25,7 @@ public class CommentFindByItemIdResponse {
     private UserInfo user;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private List<CommentInfo> replies;
+    private List<CommentFindByItemIdResponse> replies;
 
 
     @Getter
@@ -36,22 +36,6 @@ public class CommentFindByItemIdResponse {
         private String nickname;
         private String profileImgUrl;
         private Boolean isOwner;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @Builder
-    public static class CommentInfo {
-        private Long rootCommentId;
-
-        private Long id;
-        private String content;
-        private Boolean isSecret;
-        private Boolean isDeleted;
-        private LocalDateTime createdAt;
-        private LocalDateTime updatedAt;
-
-        private UserInfo user;
     }
 
     /**
@@ -85,8 +69,8 @@ public class CommentFindByItemIdResponse {
         for (Comment parent : parents) {
             List<Comment> replies = repliesGroupedByParentId.getOrDefault(parent.getId(), Collections.emptyList());
 
-            List<CommentInfo> replyResponses = replies.stream()
-                    .map(reply -> CommentInfo.builder()
+            List<CommentFindByItemIdResponse> replyResponses = replies.stream()
+                    .map(reply -> CommentFindByItemIdResponse.builder()
                             .rootCommentId(reply.getParent().getId())
                             .id(reply.getId())
                             .content(reply.getComment())

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
@@ -1,7 +1,6 @@
 package com.swyp.artego.domain.comment.dto.response;
 
 import com.swyp.artego.domain.comment.entity.Comment;
-import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,19 +11,13 @@ import java.util.List;
 @Builder
 public class CommentFindByItemIdWrapperResponse {
     private int totalComments;
-    private CommentFindByItemIdResponse.UserInfo creator;
     private List<CommentFindByItemIdResponse> comments;
     private MetaResponse meta;
 
-    public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> comments, long totalComments, MetaResponse meta) {
+    public static CommentFindByItemIdWrapperResponse from(Long itemOwnerId, List<Comment> comments, long totalComments, MetaResponse meta) {
         return CommentFindByItemIdWrapperResponse.builder()
                 .totalComments((int) totalComments)
-                .creator(CommentFindByItemIdResponse.UserInfo.builder()
-                        .id(creator.getId())
-                        .name(creator.getName())
-                        .imgUrl(creator.getImgUrl())
-                        .build())
-                .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(comments))
+                .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(comments, itemOwnerId))
                 .meta(meta)
                 .build();
     }

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/CommentFindByItemIdWrapperResponse.java
@@ -2,6 +2,7 @@ package com.swyp.artego.domain.comment.dto.response;
 
 import com.swyp.artego.domain.comment.entity.Comment;
 import com.swyp.artego.domain.user.entity.User;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,19 +11,21 @@ import java.util.List;
 @Getter
 @Builder
 public class CommentFindByItemIdWrapperResponse {
-    private int totalCount;
+    private int totalComments;
     private CommentFindByItemIdResponse.UserInfo creator;
     private List<CommentFindByItemIdResponse> comments;
+    private MetaResponse meta;
 
-    public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> comments) {
+    public static CommentFindByItemIdWrapperResponse from(User creator, List<Comment> comments, long totalComments, MetaResponse meta) {
         return CommentFindByItemIdWrapperResponse.builder()
-                .totalCount(comments.size())
+                .totalComments((int) totalComments)
                 .creator(CommentFindByItemIdResponse.UserInfo.builder()
                         .id(creator.getId())
                         .name(creator.getName())
                         .imgUrl(creator.getImgUrl())
                         .build())
                 .comments(CommentFindByItemIdResponse.convertFlatToDepth1Tree(comments))
+                .meta(meta)
                 .build();
     }
 }

--- a/src/main/java/com/swyp/artego/domain/comment/dto/response/MyCommentActivityResultResponse.java
+++ b/src/main/java/com/swyp/artego/domain/comment/dto/response/MyCommentActivityResultResponse.java
@@ -1,6 +1,6 @@
 package com.swyp.artego.domain.comment.dto.response;
 
-import com.swyp.artego.domain.item.dto.response.MetaResponse;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentQueryRepositoryImpl.java
@@ -1,19 +1,17 @@
 package com.swyp.artego.domain.comment.repository;
 
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.swyp.artego.domain.comment.dto.response.MyCommentActivityResponse;
 import com.swyp.artego.domain.comment.dto.response.MyCommentActivityResultResponse;
 import com.swyp.artego.domain.comment.entity.QComment;
-import com.swyp.artego.domain.item.dto.response.MetaResponse;
 import com.swyp.artego.domain.item.entity.QItem;
 import com.swyp.artego.domain.user.entity.QUser;
 import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.domain.user.repository.UserRepository;
 import com.swyp.artego.global.auth.oauth.model.AuthUser;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -184,8 +182,6 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
                 .meta(meta)
                 .build();
     }
-
-
 
 
     // 로그인 유저 조회

--- a/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/swyp/artego/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.swyp.artego.domain.comment.repository;
 
 import com.swyp.artego.domain.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,20 +11,31 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
 
-    // TODO: line 22, c.createdAt ASC 를 사용하면 정렬이 제대로 안되는 문제가 있음.
+    // TODO: line 19, 36, c.createdAt ASC 를 사용하면 정렬이 제대로 안되는 문제가 있음.
     @Query("""
             SELECT c
             FROM Comment c
-            WHERE c.item.id = :itemId
-            ORDER BY
-                COALESCE(c.parent.id, c.id) DESC,
-                CASE
-                    WHEN c.parent IS NULL THEN 0
-                    ELSE 1
-                END,
-                c.id ASC
+            WHERE c.item.id = :itemId AND c.parent IS NULL
+            ORDER BY c.id DESC
             """)
-    List<Comment> findByItemIdOrderByCreatedAtDesc(@Param("itemId") Long itemId);
+    Page<Comment> findRootCommentsByItemId(@Param("itemId") Long itemId, Pageable pageable);
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.parent.id IN :parentIds
+            ORDER BY c.parent.id DESC, c.id ASC
+            """)
+    List<Comment> findChildCommentsByParentIds(@Param("parentIds") List<Long> parentIds);
+
+    @Query("""
+            SELECT COUNT(c)
+            FROM Comment c
+            WHERE c.item.id = :itemId AND c.parent IS NULL
+            """)
+    Long countRootCommentsByItemId(@Param("itemId") Long itemId);
+
+    Long countAllByItemId(@Param("itemId") Long itemId);
 
     Comment findByParentId(@Param("parentId") Long parentId);
 

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentService.java
@@ -18,12 +18,8 @@ public interface CommentService {
 
     /**
      * 작품 별 댓글 전체 조회 (최신순)
-     *
-     * @param itemId 댓글을 조회할 작품 Id
-     * @return CommentFindByItemIdWrapperResponse
      */
-    CommentFindByItemIdWrapperResponse getCommentsByItemId(AuthUser authUser, Long itemId);
-
+    CommentFindByItemIdWrapperResponse getCommentsByItemId(AuthUser authUser, Long itemId, Integer page, Integer limit);
 
     /**
      * 유저 페이지 댓글 목록 (최신순)

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
@@ -95,7 +95,7 @@ public class CommentServiceImpl implements CommentService {
                 .totalItems(totalRootComments) // 전체 아이템 수
                 .hasNextPage((pageIndex + 1) * pageSize < totalComments) // 다음 페이지 존재 여부
                 .build();
-        return CommentFindByItemIdWrapperResponse.from(item.getUser(), combined, totalComments, meta);
+        return CommentFindByItemIdWrapperResponse.from(item.getUser().getId(), combined, totalComments, meta);
     }
 
 

--- a/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/comment/service/CommentServiceImpl.java
@@ -11,11 +11,16 @@ import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.domain.user.repository.UserRepository;
 import com.swyp.artego.global.auth.oauth.model.AuthUser;
 import com.swyp.artego.global.common.code.ErrorCode;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import com.swyp.artego.global.excpetion.BusinessExceptionHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,7 +59,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional(readOnly = true)
-    public CommentFindByItemIdWrapperResponse getCommentsByItemId(AuthUser authUser, Long itemId) {
+    public CommentFindByItemIdWrapperResponse getCommentsByItemId(AuthUser authUser, Long itemId, Integer page, Integer limit) {
         Long viewerId = null;
         if (authUser != null) {
             User user = userRepository.findByOauthId(authUser.getOauthId())
@@ -65,13 +70,32 @@ public class CommentServiceImpl implements CommentService {
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessExceptionHandler("존재하지 않는 작품입니다.", ErrorCode.NOT_FOUND_ERROR));
-        long itemOwnerId = item.getUser().getId();
 
-        List<Comment> comments = commentRepository.findByItemIdOrderByCreatedAtDesc(itemId);
+        int pageInput = page != null ? page : 1;
+        int pageIndex = Math.max(pageInput - 1, 0);
+        int pageSize = limit != null ? limit : 10;
 
-        applySecretPolicy(comments, viewerId, itemOwnerId);
+        Pageable pageable = PageRequest.of(pageIndex, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        List<Comment> rootComments = commentRepository.findRootCommentsByItemId(itemId, pageable).getContent();
 
-        return CommentFindByItemIdWrapperResponse.from(item.getUser(), comments);
+        List<Long> rootIds = rootComments.stream().map(Comment::getId).toList();
+        List<Comment> childComments = rootIds.isEmpty() ? List.of() : commentRepository.findChildCommentsByParentIds(rootIds);
+
+        List<Comment> combined = new ArrayList<>(rootComments);
+        combined.addAll(childComments);
+
+        applySecretPolicy(combined, viewerId, item.getUser().getId());
+
+        long totalComments = commentRepository.countAllByItemId(item.getId());
+        long totalRootComments = commentRepository.countRootCommentsByItemId(item.getId());
+
+        MetaResponse meta = MetaResponse.builder()
+                .currentPage(pageIndex + 1) // 프론트 기준으로 1-based
+                .pageSize(pageSize) // 페이지당 개수
+                .totalItems(totalRootComments) // 전체 아이템 수
+                .hasNextPage((pageIndex + 1) * pageSize < totalComments) // 다음 페이지 존재 여부
+                .build();
+        return CommentFindByItemIdWrapperResponse.from(item.getUser(), combined, totalComments, meta);
     }
 
 

--- a/src/main/java/com/swyp/artego/domain/follow/dto/response/FollowedArtistsResponse.java
+++ b/src/main/java/com/swyp/artego/domain/follow/dto/response/FollowedArtistsResponse.java
@@ -1,6 +1,6 @@
 package com.swyp.artego.domain.follow.dto.response;
 
-import com.swyp.artego.domain.item.dto.response.MetaResponse;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/swyp/artego/domain/follow/repository/FollowSearchRepositoryImpl.java
+++ b/src/main/java/com/swyp/artego/domain/follow/repository/FollowSearchRepositoryImpl.java
@@ -6,19 +6,22 @@ import com.swyp.artego.domain.follow.dto.response.FollowedArtistResponse;
 import com.swyp.artego.domain.follow.dto.response.FollowedArtistsResponse;
 import com.swyp.artego.domain.follow.entity.QFollow;
 import com.swyp.artego.domain.item.dto.response.ItemSearchResponse;
-import com.swyp.artego.domain.item.dto.response.MetaResponse;
 import com.swyp.artego.domain.item.entity.Item;
 import com.swyp.artego.domain.item.entity.QItem;
 import com.swyp.artego.domain.scrap.entity.QScrap;
 import com.swyp.artego.domain.user.entity.QUser;
 import com.swyp.artego.domain.user.entity.User;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Repository
@@ -29,7 +32,7 @@ public class FollowSearchRepositoryImpl implements FollowSearchRepository {
 
     @Override
     public FollowedArtistsResponse findFollowedArtistsWithItems(Long userId, Integer page, Integer size) {
-        if (userId== null) {
+        if (userId == null) {
             throw new IllegalArgumentException("로그인한 유저만 사용 가능합니다.");
         }
 
@@ -128,7 +131,6 @@ public class FollowSearchRepositoryImpl implements FollowSearchRepository {
                 .meta(meta)
                 .build();
     }
-
 
 
 }

--- a/src/main/java/com/swyp/artego/domain/item/dto/response/ItemSearchResultResponse.java
+++ b/src/main/java/com/swyp/artego/domain/item/dto/response/ItemSearchResultResponse.java
@@ -1,5 +1,6 @@
 package com.swyp.artego.domain.item.dto.response;
 
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/swyp/artego/domain/item/repository/ItemSearchRepositoryImpl.java
+++ b/src/main/java/com/swyp/artego/domain/item/repository/ItemSearchRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.swyp.artego.domain.user.entity.QUser;
 import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.domain.user.repository.UserRepository;
 import com.swyp.artego.global.auth.oauth.model.AuthUser;
+import com.swyp.artego.global.common.dto.response.MetaResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/swyp/artego/global/common/dto/response/MetaResponse.java
+++ b/src/main/java/com/swyp/artego/global/common/dto/response/MetaResponse.java
@@ -1,4 +1,4 @@
-package com.swyp.artego.domain.item.dto.response;
+package com.swyp.artego.global.common.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 public class MetaResponse {
     private int currentPage;
     private int pageSize;
-    private long totalItems;
+    private long totalItems; //TODO: totalCount 로 수정하기 ([댓글]에서도 사용함)
     private boolean hasNextPage;
 }

--- a/src/test/java/com/swyp/artego/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/swyp/artego/domain/comment/service/CommentServiceImplTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
@@ -86,23 +88,25 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findByItemIdOrderByCreatedAtDesc(item1.getId())
-        ).willReturn(List.of(rootComment, replyComment, replyComment2));
+        given(commentRepository.findRootCommentsByItemId(eq(item1.getId()), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(rootComment)));
+        given(commentRepository.findChildCommentsByParentIds(List.of(1L)))
+                .willReturn(List.of(replyComment, replyComment2));
 
         // when
-        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(null, item1.getId());
+        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(null, item1.getId(), null, null);
 
         // then
         List<CommentFindByItemIdResponse> comments = response.getComments();
 
         // 루트 댓글과 replies 모두의 comment 내용이 "비밀 댓글입니다." 인지 확인
         for (CommentFindByItemIdResponse commentResponse : comments) {
-            assertThat(commentResponse.getComment().getComment())
+            assertThat(commentResponse.getContent())
                     .isEqualTo("비밀 댓글입니다.");
 
             if (commentResponse.getReplies() != null) {
-                for (CommentFindByItemIdResponse.CommentInfo reply : commentResponse.getReplies()) {
-                    assertThat(reply.getComment())
+                for (CommentFindByItemIdResponse reply : commentResponse.getReplies()) {
+                    assertThat(reply.getContent())
                             .isEqualTo("비밀 댓글입니다.");
                 }
             }
@@ -128,23 +132,25 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findByItemIdOrderByCreatedAtDesc(item1.getId())
-        ).willReturn(List.of(rootComment, replyComment, replyComment2));
+        given(commentRepository.findRootCommentsByItemId(eq(item1.getId()), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(rootComment)));
+        given(commentRepository.findChildCommentsByParentIds(List.of(1L)))
+                .willReturn(List.of(replyComment, replyComment2));
 
         // when
-        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authCreator1, item1.getId());
+        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authCreator1, item1.getId(), null, null);
 
         // then
         List<CommentFindByItemIdResponse> comments = response.getComments();
 
         // 루트 댓글과 replies 모두의 comment 내용이 "비밀 댓글입니다." 이 아닌지 확인
         for (CommentFindByItemIdResponse commentResponse : comments) {
-            assertThat(commentResponse.getComment().getComment())
+            assertThat(commentResponse.getContent())
                     .isNotEqualTo("비밀 댓글입니다.");
 
             if (commentResponse.getReplies() != null) {
-                for (CommentFindByItemIdResponse.CommentInfo reply : commentResponse.getReplies()) {
-                    assertThat(reply.getComment())
+                for (CommentFindByItemIdResponse reply : commentResponse.getReplies()) {
+                    assertThat(reply.getContent())
                             .isNotEqualTo("비밀 댓글입니다.");
                 }
             }
@@ -170,23 +176,25 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findByItemIdOrderByCreatedAtDesc(item1.getId())
-        ).willReturn(List.of(rootComment, replyComment, replyComment2));
+        given(commentRepository.findRootCommentsByItemId(eq(item1.getId()), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(rootComment)));
+        given(commentRepository.findChildCommentsByParentIds(List.of(1L)))
+                .willReturn(List.of(replyComment, replyComment2));
 
         // when
-        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authUser2, item1.getId());
+        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authUser2, item1.getId(), null, null);
 
         // then
         List<CommentFindByItemIdResponse> comments = response.getComments();
 
         // 루트 댓글과 replies 모두의 comment 내용이 "비밀 댓글입니다." 이 아닌지 확인
         for (CommentFindByItemIdResponse commentResponse : comments) {
-            assertThat(commentResponse.getComment().getComment())
+            assertThat(commentResponse.getContent())
                     .isNotEqualTo("비밀 댓글입니다.");
 
             if (commentResponse.getReplies() != null) {
-                for (CommentFindByItemIdResponse.CommentInfo reply : commentResponse.getReplies()) {
-                    assertThat(reply.getComment())
+                for (CommentFindByItemIdResponse reply : commentResponse.getReplies()) {
+                    assertThat(reply.getContent())
                             .isNotEqualTo("비밀 댓글입니다.");
                 }
             }
@@ -216,23 +224,25 @@ class CommentServiceImplTest {
         given(itemRepository.findById(item1.getId())
         ).willReturn(Optional.of(item1));
 
-        given(commentRepository.findByItemIdOrderByCreatedAtDesc(item1.getId())
-        ).willReturn(List.of(rootComment, replyComment, replyComment2));
+        given(commentRepository.findRootCommentsByItemId(eq(item1.getId()), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(rootComment)));
+        given(commentRepository.findChildCommentsByParentIds(List.of(1L)))
+                .willReturn(List.of(replyComment, replyComment2));
 
         // when
-        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authUser3, item1.getId());
+        CommentFindByItemIdWrapperResponse response = commentServiceImpl.getCommentsByItemId(authUser3, item1.getId(), null, null);
 
         // then
         List<CommentFindByItemIdResponse> comments = response.getComments();
 
         // 루트 댓글과 replies 모두의 comment 내용이 "비밀 댓글입니다." 인지 확인
         for (CommentFindByItemIdResponse commentResponse : comments) {
-            assertThat(commentResponse.getComment().getComment())
+            assertThat(commentResponse.getContent())
                     .isEqualTo("비밀 댓글입니다.");
 
             if (commentResponse.getReplies() != null) {
-                for (CommentFindByItemIdResponse.CommentInfo reply : commentResponse.getReplies()) {
-                    assertThat(reply.getComment())
+                for (CommentFindByItemIdResponse reply : commentResponse.getReplies()) {
+                    assertThat(reply.getContent())
                             .isEqualTo("비밀 댓글입니다.");
                 }
             }


### PR DESCRIPTION
- 페이지네이션 구현
  - 루트 댓글 기준으로 페이지네이션. 즉, 루트 댓글 별 대댓글 개수가 상이하므로 페이지당 실제 댓글 갯수도 상이함.
- 응답 dto 구조 및 필드 전면 수정

- 이에 따른 테스트 코드 수정