### PR TITLE
feat: SSE 실시간 알림 구독 기능 및 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/swyp/artego/domain/artistApply/service/ArtistApplyServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/artistApply/service/ArtistApplyServiceImpl.java
@@ -72,7 +72,7 @@ public class ArtistApplyServiceImpl implements ArtistApplyService {
         // 대상 유저 조회
         User target = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new BusinessExceptionHandler("대상 유저를 찾을 수 없습니다.", ErrorCode.NOT_FOUND_ERROR));
-
+        
         // 작가 권한 부여
         target.setRole(Role.ARTIST);
     }

--- a/src/main/java/com/swyp/artego/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/follow/service/FollowServiceImpl.java
@@ -6,6 +6,7 @@ import com.swyp.artego.domain.follow.dto.response.FollowPreviewResponse;
 import com.swyp.artego.domain.follow.dto.response.FollowedArtistsResponse;
 import com.swyp.artego.domain.follow.entity.Follow;
 import com.swyp.artego.domain.follow.repository.FollowRepository;
+import com.swyp.artego.domain.notification.service.NotificationService;
 import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.domain.user.repository.UserRepository;
 import com.swyp.artego.global.auth.oauth.model.AuthUser;
@@ -26,6 +27,8 @@ public class FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -49,6 +52,8 @@ public class FollowServiceImpl implements FollowService {
         followRepository.save(follow);
 
         userRepository.incrementFollowerCount(artist.getId(), 1);
+
+        //notificationService.sendFollowNotification(artist, user);
     }
 
 

--- a/src/main/java/com/swyp/artego/domain/itemEmoji/service/ItemEmojiServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/itemEmoji/service/ItemEmojiServiceImpl.java
@@ -7,6 +7,7 @@ import com.swyp.artego.domain.itemEmoji.entity.ItemEmoji;
 import com.swyp.artego.domain.itemEmoji.dto.response.ItemEmojiInfoResponse;
 import com.swyp.artego.domain.itemEmoji.enums.EmojiType;
 import com.swyp.artego.domain.itemEmoji.repository.ItemEmojiRepository;
+import com.swyp.artego.domain.notification.service.NotificationService;
 import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.domain.user.repository.UserRepository;
 import com.swyp.artego.global.auth.oauth.model.AuthUser;
@@ -27,6 +28,8 @@ public class ItemEmojiServiceImpl implements ItemEmojiService {
     private final ItemEmojiRepository itemEmojiRepository;
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
+
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -63,6 +66,8 @@ public class ItemEmojiServiceImpl implements ItemEmojiService {
 
         itemRepository.incrementReactionCount(itemId, 1);
         userRepository.incrementUserReactionCount(userId, 1);
+
+        //notificationService.sendReactionNotification(item.getUser(), user, item.getId(), item.getTitle(), type);
 
         return saved.getId();
     }

--- a/src/main/java/com/swyp/artego/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/swyp/artego/domain/notification/controller/NotificationController.java
@@ -1,0 +1,62 @@
+package com.swyp.artego.domain.notification.controller;
+
+import com.swyp.artego.domain.notification.dto.response.NotificationListResponse;
+import com.swyp.artego.domain.notification.service.NotificationService;
+import com.swyp.artego.global.auth.oauth.model.AuthUser;
+import com.swyp.artego.global.common.code.SuccessCode;
+import com.swyp.artego.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "Notification", description = "알림 관련 API")
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/subscribe")
+    @Operation(summary = "SSE 알림 구독")
+    public SseEmitter subscribe(@AuthenticationPrincipal AuthUser authUser) {
+        return notificationService.subscribe(authUser);
+    }
+
+    @GetMapping("/unread")
+    @Operation(summary = "안읽은 알림 목록 조회 (페이징)")
+    public ResponseEntity<ApiResponse<NotificationListResponse>> getUnreadNotifications(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "5") int size) {
+
+        NotificationListResponse response = notificationService.getUnreadNotifications(authUser, page, size);
+
+        return ResponseEntity.status(SuccessCode.SELECT_SUCCESS.getStatus())
+                .body(ApiResponse.<NotificationListResponse>builder()
+                        .result(response)
+                        .resultCode(Integer.parseInt(SuccessCode.SELECT_SUCCESS.getCode()))
+                        .resultMessage(SuccessCode.SELECT_SUCCESS.getMessage())
+                        .build());
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "특정 알림 읽음 처리")
+    public ResponseEntity<ApiResponse<String>> markNotificationAsRead(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long notificationId) {
+
+        notificationService.markAsRead(notificationId, authUser);
+
+        return ResponseEntity.status(SuccessCode.UPDATE_SUCCESS.getStatus())
+                .body(ApiResponse.<String>builder()
+                        .result("알림이 읽음 처리되었습니다.")
+                        .resultCode(Integer.parseInt(SuccessCode.UPDATE_SUCCESS.getCode()))
+                        .resultMessage(SuccessCode.UPDATE_SUCCESS.getMessage())
+                        .build());
+    }
+}

--- a/src/main/java/com/swyp/artego/domain/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/swyp/artego/domain/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,25 @@
+package com.swyp.artego.domain.notification.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationListResponse {
+    private List<NotificationResponse> notifications;
+    private NotificationMeta meta;
+
+    @Getter
+    @Builder
+    public static class NotificationMeta {
+        private int currentPage;
+        private int pageSize;
+        private long totalNotifications;
+        private boolean hasNextPage;
+    }
+
+
+}

--- a/src/main/java/com/swyp/artego/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/swyp/artego/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,33 @@
+package com.swyp.artego.domain.notification.dto.response;
+
+import com.swyp.artego.domain.notification.entity.Notification;
+import com.swyp.artego.domain.notification.enums.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+    private Long id;
+    private NotificationType type;
+    private String content;
+    private boolean read;
+    private Map<String, Object> data;
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .content(notification.getContent())
+                .read(notification.isRead())
+                .data(notification.getData())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/swyp/artego/domain/notification/entity/Notification.java
+++ b/src/main/java/com/swyp/artego/domain/notification/entity/Notification.java
@@ -1,0 +1,58 @@
+package com.swyp.artego.domain.notification.entity;
+
+import com.swyp.artego.domain.notification.enums.NotificationType;
+import com.swyp.artego.domain.user.entity.User;
+import com.swyp.artego.global.common.entity.BaseTimeEntity;
+import com.swyp.artego.global.converter.BooleanToYNConverter;
+import com.swyp.artego.global.converter.JsonMapConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification")
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "noti_id", nullable = false)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Column(name = "noti_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+    @Convert(converter = JsonMapConverter.class)
+    @Column(columnDefinition = "json", nullable = false)
+    private Map<String, Object> data;
+
+    @Convert(converter = BooleanToYNConverter.class)
+    @Column(name = "is_read", length = 1, nullable = false)
+    private boolean read = false;
+
+    @Builder
+    private Notification(NotificationType type, User receiver, String content, Map<String, Object> data, boolean read) {
+        this.type = type;
+        this.receiver = receiver;
+        this.content = content;
+        this.data = data;
+        this.read = read;
+    }
+
+    public void markAsRead() {
+        this.read = true;
+    }
+
+
+}

--- a/src/main/java/com/swyp/artego/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/swyp/artego/domain/notification/enums/NotificationType.java
@@ -1,0 +1,8 @@
+package com.swyp.artego.domain.notification.enums;
+
+public enum NotificationType {
+    COMMENT,
+    REACTION,
+    FOLLOW,
+    SCRAP
+}

--- a/src/main/java/com/swyp/artego/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/swyp/artego/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,23 @@
+package com.swyp.artego.domain.notification.repository;
+
+import com.swyp.artego.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 1. 읽지 않은 알림 개수 (상단 뱃지 등에 사용)
+    long countByReceiverIdAndReadFalse(Long receiverId);
+
+    // 2. 알림 목록 조회 (읽음/안읽음 상관없이 모두, 최신순)
+    List<Notification> findByReceiverIdOrderByReadAscCreatedAtDesc(Long receiverId, Pageable pageable);
+
+    // 3. 읽지 않은 알림만 조회 (페이징 적용)
+    Page<Notification> findByReceiverIdAndReadFalseOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
+
+    // 4. 전체 알림 조회 (페이징 포함)
+    Page<Notification> findAllByReceiverId(Long receiverId, Pageable pageable);
+}

--- a/src/main/java/com/swyp/artego/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/swyp/artego/domain/notification/service/NotificationService.java
@@ -1,0 +1,69 @@
+package com.swyp.artego.domain.notification.service;
+
+import com.swyp.artego.domain.itemEmoji.enums.EmojiType;
+import com.swyp.artego.domain.notification.dto.response.NotificationListResponse;
+import com.swyp.artego.domain.notification.entity.Notification;
+import com.swyp.artego.domain.notification.enums.NotificationType;
+import com.swyp.artego.domain.user.entity.User;
+import com.swyp.artego.global.auth.oauth.model.AuthUser;
+import org.springframework.data.domain.Page;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface NotificationService {
+
+    /**
+     * 1. SSE 구독 요청 처리
+     * - 클라이언트가 /sse/subscribe/{userId}로 구독 요청을 보내면
+     * - 서버는 SseEmitter를 생성하여 클라이언트와 연결을 유지함
+     * - 503 방지를 위해 연결 즉시 더미 이벤트("connect")를 전송함
+     */
+    SseEmitter subscribe(AuthUser authUser);
+
+    /**
+     * 2. 알림 DB 저장 및 실시간 전송
+     * - 알림을 저장하고
+     * - 해당 유저가 SSE 구독 중이면 실시간으로 알림을 push
+     */
+
+    Notification createNotification(NotificationType type, User receiver, String content, Map<String, Object> data);
+
+    /**
+     * 3. 스크랩 알림 생성
+     * - 어떤 유저가 어떤 작품을 스크랩했는지 알림
+     */
+    void sendScrapNotification(User receiver, User sender, Long itemId, String itemTitle);
+
+    /**
+     * 4. 댓글 알림 생성
+     * - 어떤 유저가 어떤 작품에 댓글을 남겼는지 알림
+     */
+    void sendCommentNotification(User receiver, User sender, Long itemId, String itemTitle, Long commentId);
+
+    /**
+     * 5. 이모지 반응 알림 생성
+     * - 어떤 유저가 어떤 작품에 어떤 반응을 남겼는지 알림
+     */
+    void sendReactionNotification(User receiver, User sender, Long itemId, String itemTitle, EmojiType reactionType);
+
+    /**
+     * 6. 팔로우 알림 생성
+     * - 어떤 유저가 나를 팔로우 했을 때 알림
+     */
+    void sendFollowNotification(User receiver, User sender);
+
+    /**
+     * 7. 읽지 않은 알림 목록 조회
+     * - 로그인 시 읽지 않은 알림 목록 조회
+     */
+
+    NotificationListResponse getUnreadNotifications(AuthUser receiver, int page, int size);
+
+
+    /**
+     * 8. 읽지 않은 알림 읽음으로 변경
+     * - 알림 클릭 시 읽음으로 변경
+     */
+    void markAsRead(Long notificationId, AuthUser authUser);
+}

--- a/src/main/java/com/swyp/artego/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,210 @@
+package com.swyp.artego.domain.notification.service;
+
+import com.swyp.artego.domain.itemEmoji.enums.EmojiType;
+import com.swyp.artego.domain.notification.dto.response.NotificationListResponse;
+import com.swyp.artego.domain.notification.dto.response.NotificationResponse;
+import com.swyp.artego.domain.notification.entity.Notification;
+import com.swyp.artego.domain.notification.enums.NotificationType;
+import com.swyp.artego.domain.notification.repository.NotificationRepository;
+import com.swyp.artego.domain.user.entity.User;
+import com.swyp.artego.domain.user.repository.UserRepository;
+import com.swyp.artego.global.auth.oauth.model.AuthUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.service.spi.ServiceException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    private final UserRepository userRepository;
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private static final Long TIMEOUT = 60L * 1000 * 60; // 60분
+
+    @Override
+    public SseEmitter subscribe(AuthUser authUser) {
+        User user = userRepository.findByOauthId(authUser.getOauthId())
+                .orElseThrow(() -> new ServiceException("요청한 유저를 찾을 수 없습니다."));
+
+        Long userId = user.getId();
+
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitters.put(userId, emitter);
+
+//        emitter.onCompletion(() -> emitters.remove(userId));
+//        emitter.onTimeout(() -> emitters.remove(userId));
+//        emitter.onError((e) -> emitters.remove(userId));
+
+        emitter.onCompletion(() -> {
+            log.info(" SSE 완료: 유저ID={}", userId);
+            emitters.remove(userId);
+        });
+        emitter.onTimeout(() -> {
+            log.warn(" SSE 타임아웃: 유저ID={}", userId);
+            emitters.remove(userId);
+        });
+        emitter.onError((e) -> {
+            log.error(" SSE 에러 발생: 유저ID={}, error={}", userId, e.getMessage());
+            emitters.remove(userId);
+        });
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("SSE 연결 완료"));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+        return emitter;
+    }
+
+    private void sendToClient(Long receiverId, Notification notification) {
+        SseEmitter emitter = emitters.get(receiverId);
+        if (emitter != null) {
+            synchronized (emitter) {
+                try {
+                    emitter.send(SseEmitter.event()
+                            .name("new-notification")
+                            .data(NotificationResponse.from(notification)));
+                } catch (IOException e) {
+                    emitters.remove(receiverId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Notification createNotification(NotificationType type, User receiver, String content, Map<String, Object> data) {
+        Notification notification = Notification.builder()
+                .type(type)
+                .receiver(receiver)
+                .content(content)
+                .data(data)
+                .read(false)
+                .build();
+
+        Notification saved = notificationRepository.save(notification);
+        sendToClient(receiver.getId(), saved);
+        return saved;
+    }
+
+    private String nowAsString() {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    @Override
+    public void sendScrapNotification(User receiver, User sender, Long itemId, String itemTitle) {
+        String timestamp = nowAsString();
+        String content = String.format("[%s]님이 [%s] 작품을 스크랩했습니다. 일시: %s", sender.getNickname(), itemTitle, timestamp);
+        Map<String, Object> data = Map.of(
+                "sender", sender.getNickname(),
+                "itemId", itemId,
+                "itemTitle", itemTitle,
+                "timestamp", timestamp
+        );
+        createNotification(NotificationType.SCRAP, receiver, content, data);
+    }
+
+    @Override
+    public void sendCommentNotification(User receiver, User sender, Long itemId, String itemTitle, Long commentId) {
+        String timestamp = nowAsString();
+        String content = String.format("[%s]님이 [%s] 작품에 댓글을 남겼습니다. 일시: %s", sender.getNickname(), itemTitle, timestamp);
+        Map<String, Object> data = Map.of(
+                "sender", sender.getNickname(),
+                "itemId", itemId,
+                "itemTitle", itemTitle,
+                "commentId", commentId,
+                "timestamp", timestamp
+        );
+        createNotification(NotificationType.COMMENT, receiver, content, data);
+    }
+
+    @Override
+    public void sendReactionNotification(User receiver, User sender, Long itemId, String itemTitle, EmojiType reactionType) {
+        String timestamp = nowAsString();
+        String content = String.format("[%s] 님이 [%s] 작품에 [%s] 반응을 남겼습니다. 일시: %s", sender.getNickname(), itemTitle, reactionType, timestamp);
+        Map<String, Object> data = Map.of(
+                "sender", sender.getNickname(),
+                "itemId", itemId,
+                "itemTitle", itemTitle,
+                "reactionType", reactionType,
+                "timestamp", timestamp
+        );
+        createNotification(NotificationType.REACTION, receiver, content, data);
+    }
+
+    @Override
+    public void sendFollowNotification(User receiver, User sender) {
+        String timestamp = nowAsString();
+        String content = String.format("[%s]님이 [%s]님을 팔로우했습니다. 일시: %s", sender.getNickname(), receiver.getNickname(), timestamp);
+        Map<String, Object> data = Map.of(
+                "sender", sender.getNickname(),
+                "receiver", receiver.getNickname(),
+                "timestamp", timestamp
+        );
+        createNotification(NotificationType.FOLLOW, receiver, content, data);
+    }
+
+    @Override
+    public NotificationListResponse getUnreadNotifications(AuthUser authUser, int page, int size) {
+        User user = userRepository.findByOauthId(authUser.getOauthId())
+                .orElseThrow(() -> new ServiceException("요청한 유저를 찾을 수 없습니다."));
+
+        // 프론트는 page=1부터 시작하므로, 내부에서는 0부터 시작하게 조정
+        int internalPage = Math.max(page - 1, 0);
+        PageRequest pageable = PageRequest.of(internalPage, size);
+
+        Page<Notification> result = notificationRepository
+                .findByReceiverIdAndReadFalseOrderByCreatedAtDesc(user.getId(), pageable);
+
+        List<NotificationResponse> notificationResponses = result
+                .getContent()
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+
+        NotificationListResponse.NotificationMeta meta = NotificationListResponse.NotificationMeta.builder()
+                .currentPage(page) // 프론트에 다시 1-based로 돌려줌
+                .pageSize(result.getSize())
+                .totalNotifications(result.getTotalElements())
+                .hasNextPage(result.hasNext())
+                .build();
+
+        return NotificationListResponse.builder()
+                .notifications(notificationResponses)
+                .meta(meta)
+                .build();
+    }
+
+
+    @Override
+    @Transactional
+    public void markAsRead(Long notificationId, AuthUser authUser) {
+        User user = userRepository.findByOauthId(authUser.getOauthId())
+                .orElseThrow(() -> new ServiceException("요청한 유저를 찾을 수 없습니다."));
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new ServiceException("해당 알림을 찾을 수 없습니다."));
+
+        if (!notification.getReceiver().getId().equals(user.getId())) {
+            throw new ServiceException("본인의 알림만 읽음 처리할 수 있습니다.");
+        }
+
+        notification.markAsRead();
+    }
+
+
+}

--- a/src/main/java/com/swyp/artego/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/swyp/artego/domain/scrap/service/ScrapServiceImpl.java
@@ -2,6 +2,7 @@ package com.swyp.artego.domain.scrap.service;
 
 import com.swyp.artego.domain.item.entity.Item;
 import com.swyp.artego.domain.item.repository.ItemRepository;
+import com.swyp.artego.domain.notification.service.NotificationService;
 import com.swyp.artego.domain.scrap.entity.Scrap;
 import com.swyp.artego.domain.scrap.repository.ScrapRepository;
 import com.swyp.artego.domain.user.entity.User;
@@ -20,6 +21,8 @@ public class ScrapServiceImpl implements ScrapService {
     private final ScrapRepository scrapRepository;
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
+
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -44,6 +47,8 @@ public class ScrapServiceImpl implements ScrapService {
 
         itemRepository.incrementScrapCount(item.getId(), 1); // count
         userRepository.incrementUserScrapCount(item.getUser().getId(), 1); //count
+
+        //notificationService.sendScrapNotification(item.getUser(), user, item.getId(), item.getTitle());
     }
 
     @Override

--- a/src/main/java/com/swyp/artego/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/artego/global/config/SecurityConfig.java
@@ -80,6 +80,11 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/artist-applies/grant-artist-role").hasRole("ADMIN")
                                 .requestMatchers("/api/v1/artist-applies/admin").hasRole("ADMIN")
 
+                                // 13. Notification API 설정
+                                .requestMatchers("/api/v1/notifications/subscribe").authenticated()
+                                .requestMatchers("/api/v1/notifications/unread").authenticated()
+                                .requestMatchers("/api/v1/notifications/*/read").hasRole("ARTIST")
+
                                 // 기타 요청은 전부 거부
                                 .anyRequest().denyAll()
 

--- a/src/main/java/com/swyp/artego/global/converter/JsonMapConverter.java
+++ b/src/main/java/com/swyp/artego/global/converter/JsonMapConverter.java
@@ -1,0 +1,34 @@
+package com.swyp.artego.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Converter
+public class JsonMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (IOException e) {
+            return Map.of(); // 안전 처리
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
   config:
     import: optional:file:.env[.properties]
   profiles:
-    active: prod  # TODO : 올릴 때 여기 prod 로 바꿔라
+    active: local  # TODO : 올릴 때 여기 prod 로 바꿔라
 
   jackson:
     time-zone: Asia/Seoul # 대한민국 표준시 (KST)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
   config:
     import: optional:file:.env[.properties]
   profiles:
-    active: local  # TODO : 올릴 때 여기 prod 로 바꿔라
+    active: prod  # TODO : 올릴 때 여기 prod 로 바꿔라
 
   jackson:
     time-zone: Asia/Seoul # 대한민국 표준시 (KST)


### PR DESCRIPTION
1. 알림 구독 (SSE)
- GET /api/v1/notifications/subscribe

- 로그인한 사용자가 실시간 알림을 받을 수 있도록 SSE 구독

- 연결되면 "SSE 연결 완료" 메시지 전송

- 연결 종료, 타임아웃, 에러 발생 시 emitter 자동 제거

2. 안 읽은 알림 목록 조회
- GET /api/v1/notifications/unread?page=1&size=5

- 로그인한 사용자의 안 읽은 알림 목록을 페이징 처리해서 조회

- 기본값: page=1, size=5

- 응답에 전체 개수, 현재 페이지 등의 메타 정보 포함

3. 알림 읽음 처리
- PATCH /api/v1/notifications/{notificationId}/read

- 특정 알림을 읽음 처리

- 본인이 아닌 알림에 접근할 경우 예외 발생

