### PR TITLE
[User] fix: 로그인 후 권한 변경 시 세션 반영되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/swyp/artego/global/auth/oauth/controller/AuthController.java
+++ b/src/main/java/com/swyp/artego/global/auth/oauth/controller/AuthController.java
@@ -1,36 +1,51 @@
 package com.swyp.artego.global.auth.oauth.controller;
 
 
-import com.swyp.artego.domain.user.repository.UserRepository;
+import com.swyp.artego.global.auth.oauth.service.AuthService;
+import com.swyp.artego.global.common.code.SuccessCode;
+import com.swyp.artego.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
-@Slf4j
-@Controller
+
+@Controller // 이 부분은 리다이렉트용으로 유지
 @RequiredArgsConstructor
+@RequestMapping("/auth")
+@Tag(name = "Auth", description = "OAuth 인증 및 권한 관련 API")
 public class AuthController {
-
-
-
-    private final UserRepository userRepository;
-
+    private final AuthService authService;
 
     @GetMapping("/login/naver")
+    @Operation(summary = "네이버 OAuth2 로그인 리다이렉트")
     public String redirectToNaverOAuth(HttpServletRequest request,
                                        @RequestParam("redirect_uri") String redirectUri) {
         request.getSession().setAttribute("redirect_uri", redirectUri);
         return "redirect:/oauth2/authorization/naver";
     }
+    @PatchMapping("/refresh-role")
+    @ResponseBody
+    @Operation(summary = "세션 내 권한 정보 갱신")
+    public ResponseEntity<ApiResponse<String>> refreshRole(Authentication currentAuth) {
+        authService.refreshAuthentication(currentAuth);
 
+        return ResponseEntity.status(SuccessCode.UPDATE_SUCCESS.getStatus())
+                .body(ApiResponse.<String>builder()
+                        .result("권한이 성공적으로 갱신되었습니다.")
+                        .resultCode(Integer.parseInt(SuccessCode.UPDATE_SUCCESS.getCode()))
+                        .resultMessage(SuccessCode.UPDATE_SUCCESS.getMessage())
+                        .build());
+    }
 
     @GetMapping("/")
+    @Operation(summary = "홈 진입 테스트 API")
     public String home() {
         return "home";
     }
-
 
 }

--- a/src/main/java/com/swyp/artego/global/auth/oauth/dto/response/SimpleOAuth2Response.java
+++ b/src/main/java/com/swyp/artego/global/auth/oauth/dto/response/SimpleOAuth2Response.java
@@ -1,0 +1,37 @@
+package com.swyp.artego.global.auth.oauth.dto.response;
+
+import com.swyp.artego.domain.user.entity.User;
+
+public class SimpleOAuth2Response implements OAuth2Response {
+
+    private final User user;
+
+    public SimpleOAuth2Response(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getProvider() {
+        return user.getOauthId().split(" ")[0];
+    }
+
+    @Override
+    public String getProviderId() {
+        return user.getOauthId().split(" ")[1];
+    }
+
+    @Override
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+
+    @Override
+    public String getPhoneNumber() {
+        return user.getTelNumber();
+    }
+}

--- a/src/main/java/com/swyp/artego/global/auth/oauth/model/AuthUser.java
+++ b/src/main/java/com/swyp/artego/global/auth/oauth/model/AuthUser.java
@@ -1,6 +1,8 @@
 package com.swyp.artego.global.auth.oauth.model;
 
+import com.swyp.artego.domain.user.entity.User;
 import com.swyp.artego.global.auth.oauth.dto.response.OAuth2Response;
+import com.swyp.artego.global.auth.oauth.dto.response.SimpleOAuth2Response;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -14,10 +16,22 @@ public class AuthUser implements OAuth2User, UserDetails {
     private final OAuth2Response oAuth2Response;
     private final String role;
 
+
+    /**
+     * 이 생성자는 OAuth 로그인용
+     */
     public AuthUser(OAuth2Response oAuth2Response, String role) {
 
         this.oAuth2Response = oAuth2Response;
         this.role = role;
+    }
+
+    /**
+     * 이 생성자는 권한 갱신 API용
+     */
+    public AuthUser(User user) {
+        this.oAuth2Response = new SimpleOAuth2Response(user); // User → OAuth2Response로 감싸줌
+        this.role = "ROLE_" + user.getRole().name(); // DB에서 최신 권한 사용
     }
 
     @Override

--- a/src/main/java/com/swyp/artego/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/artego/global/config/SecurityConfig.java
@@ -87,7 +87,11 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/notifications/unread").authenticated()
                                 .requestMatchers("/api/v1/notifications/*/read").authenticated()
 
-                                // 기타 요청은 전부 거부
+                                // 14. Auth 관련 API
+                                .requestMatchers("/auth/refresh-role").authenticated()
+
+
+                        // 기타 요청은 전부 거부
                                 .anyRequest().denyAll()
 
                 )


### PR DESCRIPTION
🔧 What
- 로그인한 유저의 권한(Role)이 DB에서 변경된 이후에도, 세션 내 Authentication 객체에 반영되지 않는 문제를 해결합니다.

❓ Why
- Spring Security는 로그인 시 생성된 Authentication 객체를 세션에 저장하고 이후 요청마다 이를 재사용합니다.
- 따라서 DB에서 권한을 변경해도 기존 세션에는 반영되지 않아 권한 mismatch가 발생할 수 있습니다.

🛠️ How
- /auth/refresh-role API를 추가하여 프론트에서 직접 권한 갱신 요청 가능하게 구현

- 해당 API 호출 시 DB에서 유저의 권한 정보를 다시 로드하고, 새로운 Authentication 객체를 생성하여 SecurityContext에 주입

- 프론트는 작가 승인 알림 등을 받은 후 해당 API를 호출하면 세션에 최신 권한이 반영됨


