### PR TITLE
[Notification] fix: Notification과 SSE 트랜잭션 분리

### DIFF
--- a/src/main/java/com/swyp/artego/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/swyp/artego/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,28 @@
+package com.swyp.artego.domain.notification.event;
+
+import com.swyp.artego.domain.notification.entity.Notification;
+import com.swyp.artego.domain.notification.service.NotificationServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationEventListener {
+
+    private final NotificationServiceImpl notificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(NotificationSentEvent event) {
+        Notification notification = event.getNotification();
+        try {
+            notificationService.sendToClient(notification.getReceiver().getId(), notification);
+        } catch (Exception e) {
+            log.warn("[NotificationEventListener] SSE 전송 실패: id={}, reason={}", notification.getId(), e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/swyp/artego/domain/notification/event/NotificationSentEvent.java
+++ b/src/main/java/com/swyp/artego/domain/notification/event/NotificationSentEvent.java
@@ -1,0 +1,11 @@
+package com.swyp.artego.domain.notification.event;
+
+import com.swyp.artego.domain.notification.entity.Notification;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationSentEvent {
+    private final Notification notification;
+}

--- a/src/main/java/com/swyp/artego/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/swyp/artego/domain/notification/service/NotificationService.java
@@ -39,7 +39,7 @@ public interface NotificationService {
      * 4. 댓글 알림 생성
      * - 어떤 유저가 어떤 작품에 댓글을 남겼는지 알림
      */
-    void sendCommentNotification(User receiver, User sender, Long itemId, String itemTitle, Long commentId);
+    //void sendCommentNotification(User receiver, User sender, Long itemId, String itemTitle, Long commentId);
 
     /**
      * 5. 이모지 반응 알림 생성


### PR DESCRIPTION
댓글 생성 시 알림도 같은 트랜잭션으로 저장
- 댓글과 알림 간 데이터 정합성 확보
- 실패 시 둘 다 rollback 되어 불일치 방지

트랜잭션 커밋 이후에만 SSE 전송 수행
- @TransactionalEventListener(phase = AFTER_COMMIT) 사용
- 실패한 트랜잭션에 대해 사용자에게 알림 전송 방지