### PR TITLE
모니터링 시스템 구축

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,6 +49,7 @@ jobs:
             
             docker run -d \
               --name artego \
+              --network artego \
               -p ${{ secrets.APP_PORT_EXTERNAL_INTERNAL }} \
               --env-file .env \
               -e SPRING_PROFILES_ACTIVE=prod \

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -1,3 +1,4 @@
+#실행 명령어: docker compose -f docker-compose.monitoring.yml up --build -d
 version: '3.7'
 
 services:

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ~/prometheus/prometheus-config/:/etc/prometheus/
+      - ~/prometheus/prometheus-volume:/prometheus
+    ports:
+      - 9090:9090
+    command: # web.enalbe-lifecycle은 api 재시작없이 설정파일들을 reload 할 수 있게 해줌
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    #    restart: always
+    networks:
+      - artego
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    # user: "$GRA_UID:$GRA_GID"
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    volumes:
+      - ~/prometheus/grafana-volume:/var/lib/grafana
+    #    restart: always
+    networks:
+      - artego
+
+networks:
+  artego:
+    external: true # 사전에 만들어진 네트워크를 사용한다는 뜻

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,0 +1,59 @@
+# (docker-compose.monitoring.yml 기준) ~/prometheus/prometheus-config/prometheus.yml 에 작성하는 내용
+
+# default 값 설정하기 - 여기 부분은 전부 설정 안해줘도 상관없음
+global:
+  scrape_interval: 15s # scrap target의 기본 interval을 15초로 변경 / default = 1m
+  scrape_timeout: 15s # scrap request 가 timeout 나는 길이 / default = 10s
+  evaluation_interval: 2m # rule 을 얼마나 빈번하게 검증하는지 / default = 1m
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'artego-monitor' # 기본적으로 붙여줄 라벨
+  #query_log_file: 로그가저장될파일주소.log # prometheus의 쿼리 로그들을 기록, 없으면 기록안함
+
+# 규칙을 로딩하고 'evaluation_interval' 설정에 따라 정기적으로 평가한다.
+rule_files:
+  - "rule.yml" # 파일위치는 prometheus.yml 이 있는 곳과 동일 위치
+
+# 매트릭을 수집할 엔드포인드로 여기선 Prometheus 서버 자신을 가리킨다.
+scrape_configs:
+  # 이 설정에서 수집한 타임시리즈에 `job=<job_name>`으로 잡의 이름을 설정한다.
+  # metrics_path의 기본 경로는 '/metrics'이고 scheme의 기본값은 `http`다
+  - job_name: 'spring-actuator' # job_name 은 모든 scrap 내에서 고유해야함
+    scrape_interval: 10s # global에서 default 값을 정의해주었기 떄문에 안써도됨
+    scrape_timeout: 10s # global에서 default 값을 정의해주었기 떄문에 안써도됨
+    metrics_path: '/actuator/prometheus' # 옵션 - prometheus 가 metrics를 얻기위해 참조하는 uri 를 변경할 수 있음 | default = /metrics
+    honor_labels: false # 옵션 - 라벨 충동이 있을경우 라벨을 변경할지설정(false일 경우 라벨 안바뀜) | default = false
+    honor_timestamps: false # 옵션 - honor_labels 이 참일 경우, metrics timestamp가 노출됨(true 일경우) | default = false
+    scheme: 'http' # 옵션 - request 를 보낼 scheme 설정 | default = http
+    params: # 옵션 - request 요청 보낼 떄의 param
+      user-id: [ 'swypweb9team7@gmail.com' ]
+
+    # 그 외에도 authorization 설정
+    # service discovery 설정(sd)
+
+    # 실제 scrap 하는 타겟에 관한 설정
+    static_configs:
+      - targets: [ 'artego:8000' ] # prometheus, node-exporter, cadvisor
+        labels: # 옵션 - scrap 해서 가져올 metrics 들 전부에게 붙여줄 라벨
+          service: 'spring-actuator'
+
+    # relabel_config - 스크랩되기 전의 label들을 수정
+    # metric_relabel_configs - 가져오는 대상들의 레이블들을 동적으로 다시작성하는 설정(drop, replace, labeldrop)
+
+  - job_name: "prometheus"
+    metrics_path: '/metrics' # 옵션 - default = /metrics
+    scheme: 'http' # 옵션 - default = http
+    static_configs:
+      - targets: [ 'localhost:9090' ] # prometheus, node-exporter, cadvisor
+        labels: # 옵션 - scrap 해서 가져올 metrics 들 전부에게 붙여줄 라벨
+          service: 'prometheus'
+
+
+# Alerting specifies settings related to the Alertmanager.
+#alerting:
+#  alert_relabel_configs:
+#    [ - <relabel_config> ... ]
+#  alertmanagers:
+#    [ - <alertmanager_config> ... ]

--- a/infra/monitoring/rule.yml
+++ b/infra/monitoring/rule.yml
@@ -1,0 +1,23 @@
+# (prometheus.yml 기준) ~/prometheus/prometheus-config/rule.yml 에 작성하는 내용
+
+groups:
+  - name: example1 # 파일 내에서 unique 해야함
+    rules:
+
+      # 어떤 인스턴스든 5분 이상 다운되어 있으면 감지한다.
+      - alert: InstanceDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: "Instance {{ $labels.instance }} down"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
+
+      # API 요청 지연시간(latency)의 중앙값(quantile 0.5)이 1초를 초과하는 액션이 10분 이상 지속되면 감지한다.
+      - alert: APIHighRequestLatency
+        expr: api_http_request_latencies_second{quantile="0.5"} > 1
+        for: 10m
+        annotations:
+          summary: "High request latency on {{ $labels.instance }}"
+          description: "{{ $labels.instance }} has a median request latency above 1s (current value: {{ $value }}s)"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,3 +50,19 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
+management:
+  endpoints:
+    jmx:
+      exposure:
+        include: health, info, prometheus, metrics
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+        exclude:
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      access: read_only


### PR DESCRIPTION
- spring actuator, prometheus 의존성 추가
- infra/monitoring 에 prometheus, grafana를 실행하는 docker-compose.monitoring.yml 파일, prometheus 설정 파일, rule 설정 파일(제대로 사용하기 위해서는 Alertmanager를 도입해야함. 아직 Alertmanager는 실행하지 않는 상태.)

- 다음 네 개의 컨테이너를 도커 네트워크 `artego` 로 묶음 
  - spring boot
  - mysql
  - prometheus
  - grafana